### PR TITLE
Disable setEnvironment

### DIFF
--- a/src/plugins/languageclient/languageclientinterface.cpp
+++ b/src/plugins/languageclient/languageclientinterface.cpp
@@ -116,10 +116,10 @@ void StdIOClientInterface::startImpl()
     m_logFile.write(QString("Starting server: %1\nOutput:\n\n").arg(m_cmd.toUserOutput()).toUtf8());
     m_process->setCommand(m_cmd);
     m_process->setWorkingDirectory(m_workingDirectory);
-    if (m_env)
-        m_process->setEnvironment(*m_env);
-    else
-        m_process->setEnvironment(m_cmd.executable().deviceEnvironment());
+    // if (m_env)
+    //     m_process->setEnvironment(*m_env);
+    // else
+    //     m_process->setEnvironment(m_cmd.executable().deviceEnvironment());
     m_process->setAllowCoreDumps(m_allowCoreDumps);
     m_process->start();
 }


### PR DESCRIPTION
Only to build a debug build on macOS